### PR TITLE
Add browser config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A telescope plugin for Hoogle.
 ## Installation
 
 1. Install [Telescope](https://github.com/nvim-telescope/telescope.nvim)
-1. Install a recent Hoogle (needs to support `--json` flag)
-2. Run `hoogle generate`
-3. Install this plugin (for example: `paq 'luc-tielen/telescope_hoogle'`)
-4. Add the following Lua snippet to your nvim config:
+2. Install a recent Hoogle (needs to support `--json` flag)
+3. Run `hoogle generate`
+4. Install this plugin (for example: `paq 'luc-tielen/telescope_hoogle'`)
+5. Add the following Lua snippet to your nvim config:
 
 ```lua
 local telescope = require('telescope')
@@ -27,6 +27,28 @@ telescope.setup {
   -- opts...
 }
 telescope.load_extension('hoogle')
+```
+
+## Usage
+
+```lua
+-- Use telescope_hoogle with custom settings:
+require('telescope').extensions.hoogle.hoogle({
+
+    browser_cmd = "firefox -P search", -- leave empty for defaults.
+    count = 50 -- leave empty for defaults.
+
+    })
+```
+
+You can create a keybind for easy access:
+```lua
+-- lua
+vim.api.nvim_set_keymap('n', '<leader>ho', '<cmd>lua require("telescope").extensions.hoogle.hoogle({browser_cmd="firefox -P search"})<cr>')
+```
+```vimscript
+-- vimscript
+nnoremap <leader>ho <cmd>lua require("telescope").extensions.hoogle.hoogle({browser_cmd="firefox -P search"})<cr>
 ```
 
 ## Development

--- a/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
+++ b/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
@@ -1,5 +1,4 @@
 local pickers = require 'telescope.pickers'
-local finders = require 'telescope.finders'
 local actions = require 'telescope.actions'
 local actions_state = require 'telescope.actions.state'
 local previewers = require 'telescope.previewers'
@@ -87,16 +86,11 @@ local function copy_to_clipboard(text)
   vim.fn.setreg(reg, text)
 end
 
-local function open_browser(url)
-  local browser_cmd
-  if vim.fn.has('unix') == 1 then
-    browser_cmd = 'sensible-browser'
+local function open_browser(browser_cmd, url)
+  if not browser_cmd or browser_cmd == "" then
+      error("telescope_hoogle: unable to open browser, no command specified.")
+      return
   end
-  if vim.fn.has('mac') == 1 then
-    browser_cmd = 'open'
-  end
-  -- TODO: windows support?
-
   vim.cmd(':silent !' .. browser_cmd .. ' ' .. vim.fn.fnameescape(url))
 end
 
@@ -120,7 +114,7 @@ local function live_hoogle_search(opts)
       end)
       map('i', '<C-b>', function()
         local entry = actions_state.get_selected_entry()
-        open_browser(entry.url)
+        open_browser(opts.browser_cmd, entry.url)
         actions.close(buf)
       end)
 
@@ -135,9 +129,19 @@ local function setup(opts)
     return
   end
 
+  local browser_cmd = ""
+  if vim.fn.has('unix') == 1 then
+      browser_cmd = 'sensible-browser'
+  end
+  if vim.fn.has('mac') == 1 then
+      browser_cmd = 'open'
+  end
+  -- TODO: Add Windows default?
+
   opts = merge(opts or {}, {
     layout_strategy = 'horizontal',
-    layout_config = { preview_width = 80 }
+    layout_config = { preview_width = 80 },
+    browser_cmd = browser_cmd,
   })
 
   live_hoogle_search(opts)

--- a/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
+++ b/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
@@ -1,4 +1,5 @@
 local pickers = require 'telescope.pickers'
+local sorters = require 'telescope.sorters'
 local actions = require 'telescope.actions'
 local actions_state = require 'telescope.actions.state'
 local previewers = require 'telescope.previewers'
@@ -104,6 +105,7 @@ local function live_hoogle_search(opts)
   pickers.new(opts, {
     prompt_title = 'Live Hoogle search',
     finder = finder,
+    sorter = sorters.get_generic_fuzzy_sorter(opts),
     -- TODO don't use display_content
     previewer = previewers.display_content.new(opts),
     attach_mappings = function(buf, map)

--- a/lua/telescope/_extensions/hoogle/preprocess_job.lua
+++ b/lua/telescope/_extensions/hoogle/preprocess_job.lua
@@ -26,7 +26,7 @@ function JobFinder:new(opts)
   opts = opts or {}
 
   local obj = setmetatable({
-    entry_maker = opts.entry_maker or make_entry.from_string,
+    entry_maker = opts.entry_maker,
     fn_command = opts.fn_command,
     fn_preprocess = opts.fn_preprocess or default_preprocess,
     cwd = opts.cwd,


### PR DESCRIPTION
First of, thanks for your talk about `souffle-haskell`, I highly enjoyed that one ;D

I was in need of configuring the browser command, which is used to open the urls, so I thought why not make a PR for this (:

I did not find a good way to circumvent creating a "global" Hoogle module,  which is returned in `hoogle/live_hoogle_search.lua` and now exposes `H.setup()` and `H.live_hoogle_search()`. The way I understood telescope is, that defaults should be set in the `telescope.setup({ extensions = { -- extension_name = { extension_opts... } })` hook by the user.

You can also read the first commit message.

If you want me to change something, do not hesitate. Maybe you even have an idea which allows this to be less stateful. (I was hoping for telescope to pass standard `opts` to an extension's exposed functions but this does not seem to be the case :/ )

Kind regards, ndzik.