### PR TITLE
fix: do not force telescope layout

### DIFF
--- a/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
+++ b/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
@@ -80,7 +80,7 @@ local function preprocess_data(data)
 end
 
 local function merge(...)
-  return vim.tbl_extend('keep', ...)
+  return vim.tbl_extend('force', ...)
 end
 
 local function copy_to_clipboard(text)


### PR DESCRIPTION
The `'keep'` strategy of extending a table means the default layout is forced and it is not possible to override it.

The `'force'` strategy allows users to override the defaults.