### PR TITLE
fix: highlight group from Structure to Include

### DIFF
--- a/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
+++ b/lua/telescope/_extensions/hoogle/live_hoogle_search.lua
@@ -56,7 +56,7 @@ local function make_display(entry)
       { remaining = true },
     }
   }
-  return displayer { {module, "Structure"}, {entry.type_sig, "Type"} }
+  return displayer { {module, "Include"}, {entry.type_sig, "Type"} }
 end
 
 local function entry_maker(data)


### PR DESCRIPTION
The highlight group _Structure_ links to _Type_ (at least in my NeoVim), so there is no color difference between module and type signature. By changing highlight group to _Include_, I think things will work better for others like me.

PS: `:Telescope highlights` is a good way to examine highlight groups.